### PR TITLE
Implement collection blocks

### DIFF
--- a/frontend/src/blockly/basicToolbox.ts
+++ b/frontend/src/blockly/basicToolbox.ts
@@ -85,6 +85,17 @@ export const basicToolbox: ToolboxDefinition = {
     },
     {
       kind: 'category',
+      name: 'Collections',
+      colour: '#5CA699',
+      contents: [
+        { kind: 'block', type: 'collection_filter' },
+        { kind: 'block', type: 'collection_map' },
+        { kind: 'block', type: 'collection_reduce' },
+        { kind: 'block', type: 'collection_sort' },
+      ],
+    },
+    {
+      kind: 'category',
       name: 'База данных',
       colour: '#A6745C',
       contents: [

--- a/frontend/src/blockly/demo/collectionDemo.ts
+++ b/frontend/src/blockly/demo/collectionDemo.ts
@@ -1,0 +1,39 @@
+export const collectionDemoXml = `
+<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="collection_reduce" x="20" y="20">
+    <field name="OP">SUM</field>
+    <field name="FIELD"></field>
+    <value name="COLLECTION">
+      <block type="collection_map">
+        <field name="VAR">n</field>
+        <value name="COLLECTION">
+          <block type="collection_filter">
+            <field name="VAR">n</field>
+            <value name="COLLECTION">
+              <block type="lists_create_with">
+                <mutation items="3" />
+                <value name="ADD0"><block type="math_number"><field name="NUM">1</field></block></value>
+                <value name="ADD1"><block type="math_number"><field name="NUM">2</field></block></value>
+                <value name="ADD2"><block type="math_number"><field name="NUM">3</field></block></value>
+              </block>
+            </value>
+            <value name="CONDITION">
+              <block type="logic_compare">
+                <field name="OP">GT</field>
+                <value name="A"><block type="variables_get"><field name="VAR">n</field></block></value>
+                <value name="B"><block type="math_number"><field name="NUM">1</field></block></value>
+              </block>
+            </value>
+          </block>
+        </value>
+        <value name="TRANSFORM">
+          <block type="math_arithmetic">
+            <field name="OP">MULTIPLY</field>
+            <value name="A"><block type="variables_get"><field name="VAR">n</field></block></value>
+            <value name="B"><block type="math_number"><field name="NUM">10</field></block></value>
+          </block>
+        </value>
+      </block>
+    </value>
+  </block>
+</xml>`

--- a/frontend/src/customBlocks/collectionBlocks.test.ts
+++ b/frontend/src/customBlocks/collectionBlocks.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as Blockly from 'blockly/node'
+import { javascriptGenerator } from 'blockly/javascript'
+import './collectionBlocks'
+
+let workspace: Blockly.Workspace
+
+beforeEach(() => {
+  workspace = new Blockly.Workspace()
+  javascriptGenerator.init(workspace)
+})
+
+describe('collection_filter generator', () => {
+  it('generates filter code', () => {
+    const block = workspace.newBlock('collection_filter')
+    const arrVar = workspace.createVariable('arr')
+    const arrBlock = workspace.newBlock('variables_get')
+    arrBlock.setFieldValue(arrVar.getId(), 'VAR')
+    block.getInput('COLLECTION')!.connection!.connect(arrBlock.outputConnection!)
+    const cond = workspace.newBlock('logic_boolean')
+    cond.setFieldValue('TRUE', 'BOOL')
+    block.getInput('CONDITION')!.connection!.connect(cond.outputConnection!)
+    block.setFieldValue('x', 'VAR')
+
+    const code = javascriptGenerator.blockToCode(block) as [string, number]
+    expect(code[0]).toMatch(/arr\.filter\(\(.+\) => true\)/)
+  })
+})
+
+describe('collection_map generator', () => {
+  it('generates map code', () => {
+    const block = workspace.newBlock('collection_map')
+    const arrVar = workspace.createVariable('arr')
+    const arrBlock = workspace.newBlock('variables_get')
+    arrBlock.setFieldValue(arrVar.getId(), 'VAR')
+    block.getInput('COLLECTION')!.connection!.connect(arrBlock.outputConnection!)
+    const num = workspace.newBlock('math_number')
+    num.setFieldValue('2', 'NUM')
+    block.getInput('TRANSFORM')!.connection!.connect(num.outputConnection!)
+    block.setFieldValue('i', 'VAR')
+
+    const code = javascriptGenerator.blockToCode(block) as [string, number]
+    expect(code[0]).toMatch(/arr\.map\(\(.+\) => 2\)/)
+  })
+})
+
+describe('collection_reduce generator', () => {
+  it('generates reduce code for SUM', () => {
+    const block = workspace.newBlock('collection_reduce')
+    const arrVar = workspace.createVariable('arr')
+    const arrBlock = workspace.newBlock('variables_get')
+    arrBlock.setFieldValue(arrVar.getId(), 'VAR')
+    block.getInput('COLLECTION')!.connection!.connect(arrBlock.outputConnection!)
+    block.setFieldValue('SUM', 'OP')
+    block.setFieldValue('value', 'FIELD')
+
+    const code = javascriptGenerator.blockToCode(block) as [string, number]
+    expect(code[0]).toBe("arr.map(item => item['value']).reduce((a,b)=>a+b,0)")
+  })
+})
+
+describe('collection_sort generator', () => {
+  it('generates sort code', () => {
+    const block = workspace.newBlock('collection_sort')
+    const arrVar = workspace.createVariable('arr')
+    const arrBlock = workspace.newBlock('variables_get')
+    arrBlock.setFieldValue(arrVar.getId(), 'VAR')
+    block.getInput('COLLECTION')!.connection!.connect(arrBlock.outputConnection!)
+    block.setFieldValue('name', 'FIELD')
+
+    const code = javascriptGenerator.blockToCode(block) as [string, number]
+    expect(code[0]).toBe("arr.slice().sort((a,b)=>a['name']>b['name']?1:-1)")
+  })
+})

--- a/frontend/src/customBlocks/collectionBlocks.ts
+++ b/frontend/src/customBlocks/collectionBlocks.ts
@@ -1,0 +1,132 @@
+import * as Blockly from 'blockly/core'
+import { javascriptGenerator } from 'blockly/javascript'
+
+export const TYPE_COLORS = {
+  Array: 260,
+  Object: 20,
+  String: 160,
+} as const
+
+export function registerCollectionBlocks() {
+  Blockly.Blocks['collection_filter'] = {
+    init() {
+      this.appendValueInput('COLLECTION')
+        .setCheck('Array')
+        .appendField('filter')
+      this.appendDummyInput()
+        .appendField('item as')
+        .appendField(new Blockly.FieldVariable('item'), 'VAR')
+      this.appendValueInput('CONDITION')
+        .setCheck('Boolean')
+        .appendField('where')
+      this.setOutput(true, 'Array')
+      this.setColour(TYPE_COLORS.Array)
+      this.setTooltip('Filter collection by condition')
+    },
+  }
+
+  Blockly.Blocks['collection_map'] = {
+    init() {
+      this.appendValueInput('COLLECTION')
+        .setCheck('Array')
+        .appendField('map')
+      this.appendDummyInput()
+        .appendField('item as')
+        .appendField(new Blockly.FieldVariable('item'), 'VAR')
+      this.appendValueInput('TRANSFORM')
+        .appendField('to')
+      this.setOutput(true, 'Array')
+      this.setColour(TYPE_COLORS.Array)
+      this.setTooltip('Transform each element')
+    },
+  }
+
+  Blockly.Blocks['collection_reduce'] = {
+    init() {
+      this.appendValueInput('COLLECTION')
+        .setCheck('Array')
+        .appendField('aggregate')
+      this.appendDummyInput()
+        .appendField(new Blockly.FieldDropdown([
+          ['sum', 'SUM'],
+          ['avg', 'AVG'],
+          ['min', 'MIN'],
+          ['max', 'MAX'],
+        ]), 'OP')
+      this.appendDummyInput()
+        .appendField('field')
+        .appendField(new Blockly.FieldTextInput('value'), 'FIELD')
+      this.setOutput(true, 'Number')
+      this.setColour(TYPE_COLORS.Array)
+      this.setTooltip('Aggregate values of a field')
+    },
+  }
+
+  Blockly.Blocks['collection_sort'] = {
+    init() {
+      this.appendValueInput('COLLECTION')
+        .setCheck('Array')
+        .appendField('sort')
+      this.appendDummyInput()
+        .appendField('by')
+        .appendField(new Blockly.FieldTextInput('field'), 'FIELD')
+      this.setOutput(true, 'Array')
+      this.setColour(TYPE_COLORS.Array)
+      this.setTooltip('Sort array by field')
+    },
+  }
+
+  const jexlGenerator = javascriptGenerator
+
+  jexlGenerator['collection_filter'] = function (block) {
+    const collection = jexlGenerator.valueToCode(block, 'COLLECTION', jexlGenerator.ORDER_NONE) || '[]'
+    const variable = block.getFieldValue('VAR')
+    const condition = jexlGenerator.valueToCode(block, 'CONDITION', jexlGenerator.ORDER_NONE) || 'true'
+    const code = `${collection}.filter((${variable}) => ${condition})`
+    return [code, jexlGenerator.ORDER_FUNCTION_CALL]
+  }
+
+  jexlGenerator['collection_map'] = function (block) {
+    const collection = jexlGenerator.valueToCode(block, 'COLLECTION', jexlGenerator.ORDER_NONE) || '[]'
+    const variable = block.getFieldValue('VAR')
+    const transform = jexlGenerator.valueToCode(block, 'TRANSFORM', jexlGenerator.ORDER_NONE) || variable
+    const code = `${collection}.map((${variable}) => ${transform})`
+    return [code, jexlGenerator.ORDER_FUNCTION_CALL]
+  }
+
+  jexlGenerator['collection_reduce'] = function (block) {
+    const collection = jexlGenerator.valueToCode(block, 'COLLECTION', jexlGenerator.ORDER_NONE) || '[]'
+    const field = block.getFieldValue('FIELD')
+    const op = block.getFieldValue('OP')
+    const values = field
+      ? `${collection}.map(item => item['${field}'])`
+      : collection
+    let code
+    switch (op) {
+      case 'SUM':
+        code = `${values}.reduce((a,b)=>a+b,0)`
+        break
+      case 'AVG':
+        code = `(${values}.reduce((a,b)=>a+b,0))/(${values}.length)`
+        break
+      case 'MIN':
+        code = `${values}.reduce((a,b)=>a<b?a:b,Infinity)`
+        break
+      case 'MAX':
+        code = `${values}.reduce((a,b)=>a>b?a:b,-Infinity)`
+        break
+      default:
+        code = `${values}.reduce((a,b)=>a+b,0)`
+    }
+    return [code, jexlGenerator.ORDER_FUNCTION_CALL]
+  }
+
+  jexlGenerator['collection_sort'] = function (block) {
+    const collection = jexlGenerator.valueToCode(block, 'COLLECTION', jexlGenerator.ORDER_NONE) || '[]'
+    const field = block.getFieldValue('FIELD')
+    const code = `${collection}.slice().sort((a,b)=>a['${field}']>b['${field}']?1:-1)`
+    return [code, jexlGenerator.ORDER_FUNCTION_CALL]
+  }
+}
+
+registerCollectionBlocks()

--- a/frontend/src/customBlocks/databaseBlocks.ts
+++ b/frontend/src/customBlocks/databaseBlocks.ts
@@ -1,5 +1,6 @@
 import * as Blockly from 'blockly/core'
 import { javascriptGenerator } from 'blockly/javascript'
+import { TYPE_COLORS } from './collectionBlocks'
 
 const TABLES = ['users', 'orders']
 
@@ -14,7 +15,7 @@ export function registerDatabaseBlocks() {
         .setCheck('String')
         .appendField('where')
       this.setOutput(true, 'Array')
-      this.setColour(230)
+      this.setColour(TYPE_COLORS.Array)
       this.setTooltip('Query table')
     },
   }
@@ -27,7 +28,7 @@ export function registerDatabaseBlocks() {
         .appendField('.')
         .appendField(new Blockly.FieldTextInput('field'), 'FIELD')
       this.setOutput(true)
-      this.setColour(230)
+      this.setColour(TYPE_COLORS.Object)
       this.setTooltip('Get field from record')
     },
   }

--- a/frontend/src/pages/AlgorithmBuilder.tsx
+++ b/frontend/src/pages/AlgorithmBuilder.tsx
@@ -4,6 +4,8 @@ import BlocklyWorkspace from '../components/BlocklyWorkspace'
 import type { BlocklyWorkspaceHandle } from '../components/BlocklyWorkspace'
 import { basicToolbox } from '../blockly/basicToolbox'
 import '../customBlocks/databaseBlocks'
+import '../customBlocks/collectionBlocks'
+import { collectionDemoXml } from '../blockly/demo/collectionDemo'
 
 export default function AlgorithmBuilder() {
   const workspaceRef = useRef<BlocklyWorkspaceHandle>(null)
@@ -48,6 +50,7 @@ export default function AlgorithmBuilder() {
       <BlocklyWorkspace
         ref={workspaceRef}
         toolbox={basicToolbox}
+        initialXml={collectionDemoXml}
         className="blockly-container"
       />
    </div>


### PR DESCRIPTION
## Summary
- add custom collectionBlocks with filter, map, reduce and sort blocks
- colour blocks depending on type
- extend toolbox and algorithm builder demo with new blocks
- provide generator tests and demo XML example

## Testing
- `npm test --silent`
- `mvn -q test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68864c263448832e94b30936714e800d