### PR TITLE
Implement regex backend service

### DIFF
--- a/src/main/java/com/dataflow/controller/RegexController.java
+++ b/src/main/java/com/dataflow/controller/RegexController.java
@@ -1,0 +1,42 @@
+package com.dataflow.controller;
+
+import com.dataflow.dto.RegexTestRequest;
+import com.dataflow.dto.RegexTestResponse;
+import com.dataflow.dto.RegexValidateRequest;
+import com.dataflow.regex.RegexService;
+import com.dataflow.regex.RegexTemplateLibrary;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/regex")
+public class RegexController {
+
+    private final RegexService service;
+    private final RegexTemplateLibrary library;
+
+    public RegexController(RegexService service, RegexTemplateLibrary library) {
+        this.service = service;
+        this.library = library;
+    }
+
+    @PostMapping("/validate")
+    public Map<String, Boolean> validate(@RequestBody RegexValidateRequest request) {
+        boolean valid = service.validateRegex(request.getPattern());
+        return Map.of("valid", valid);
+    }
+
+    @PostMapping("/test")
+    public RegexTestResponse test(@RequestBody RegexTestRequest request) {
+        RegexTestResponse resp = new RegexTestResponse();
+        resp.setResults(service.testRegex(request.getPattern(), request.getTestCases()));
+        return resp;
+    }
+
+    @GetMapping("/templates")
+    public Map<String, String> templates() {
+        return library.getTemplates();
+    }
+}

--- a/src/main/java/com/dataflow/dto/RegexTestRequest.java
+++ b/src/main/java/com/dataflow/dto/RegexTestRequest.java
@@ -1,0 +1,11 @@
+package com.dataflow.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class RegexTestRequest {
+    private String pattern;
+    private List<String> testCases;
+}

--- a/src/main/java/com/dataflow/dto/RegexTestResponse.java
+++ b/src/main/java/com/dataflow/dto/RegexTestResponse.java
@@ -1,0 +1,10 @@
+package com.dataflow.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class RegexTestResponse {
+    private List<Boolean> results;
+}

--- a/src/main/java/com/dataflow/dto/RegexValidateRequest.java
+++ b/src/main/java/com/dataflow/dto/RegexValidateRequest.java
@@ -1,0 +1,8 @@
+package com.dataflow.dto;
+
+import lombok.Data;
+
+@Data
+public class RegexValidateRequest {
+    private String pattern;
+}

--- a/src/main/java/com/dataflow/regex/RegexService.java
+++ b/src/main/java/com/dataflow/regex/RegexService.java
@@ -1,0 +1,47 @@
+package com.dataflow.regex;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+@Service
+public class RegexService {
+
+    @Cacheable(value = "regexPatterns", key = "#pattern")
+    protected Pattern compilePattern(String pattern) {
+        return Pattern.compile(pattern);
+    }
+
+    public boolean validateRegex(String pattern) {
+        try {
+            compilePattern(pattern);
+            return true;
+        } catch (PatternSyntaxException ex) {
+            return false;
+        }
+    }
+
+    public List<Boolean> testRegex(String pattern, List<String> testCases) {
+        Pattern p = compilePattern(pattern);
+        List<Boolean> results = new ArrayList<>();
+        for (String s : testCases) {
+            results.add(p.matcher(s).find());
+        }
+        return results;
+    }
+
+    public List<String> getMatches(String pattern, String text) {
+        Pattern p = compilePattern(pattern);
+        Matcher m = p.matcher(text);
+        List<String> matches = new ArrayList<>();
+        while (m.find()) {
+            matches.add(m.group());
+        }
+        return matches;
+    }
+}

--- a/src/main/java/com/dataflow/regex/RegexTemplateLibrary.java
+++ b/src/main/java/com/dataflow/regex/RegexTemplateLibrary.java
@@ -1,0 +1,18 @@
+package com.dataflow.regex;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class RegexTemplateLibrary {
+    private final Map<String, String> templates = Map.of(
+            "Email", "^[\\w.-]+@[\\w.-]+\\.[A-Za-z]{2,6}$",
+            "IPv4", "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+            "UUID", "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    );
+
+    public Map<String, String> getTemplates() {
+        return templates;
+    }
+}

--- a/src/test/java/com/dataflow/controller/RegexControllerTest.java
+++ b/src/test/java/com/dataflow/controller/RegexControllerTest.java
@@ -1,0 +1,51 @@
+package com.dataflow.controller;
+
+import com.dataflow.dto.RegexTestRequest;
+import com.dataflow.dto.RegexTestResponse;
+import com.dataflow.dto.RegexValidateRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class RegexControllerTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void validateEndpoint() {
+        RegexValidateRequest req = new RegexValidateRequest();
+        req.setPattern("a+");
+        ResponseEntity<Map> resp = restTemplate.postForEntity("/api/regex/validate", req, Map.class);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody().get("valid")).isEqualTo(true);
+    }
+
+    @Test
+    void testEndpoint() {
+        RegexTestRequest req = new RegexTestRequest();
+        req.setPattern("a+");
+        req.setTestCases(List.of("a", "b"));
+        ResponseEntity<RegexTestResponse> resp = restTemplate.postForEntity("/api/regex/test", req, RegexTestResponse.class);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody().getResults()).containsExactly(true, false);
+    }
+
+    @Test
+    void templatesEndpoint() {
+        ResponseEntity<Map> resp = restTemplate.getForEntity("/api/regex/templates", Map.class);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(((Map<?,?>)resp.getBody()).size()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/com/dataflow/regex/RegexServiceTest.java
+++ b/src/test/java/com/dataflow/regex/RegexServiceTest.java
@@ -1,0 +1,71 @@
+package com.dataflow.regex;
+
+import com.dataflow.regex.RegexService;
+import com.dataflow.regex.RegexTemplateLibrary;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RegexServiceTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        CountingRegexService regexService() {
+            return new CountingRegexService();
+        }
+        @Bean
+        RegexTemplateLibrary templateLibrary() {
+            return new RegexTemplateLibrary();
+        }
+    }
+
+    static class CountingRegexService extends RegexService {
+        AtomicInteger count = new AtomicInteger();
+        @Override
+        @org.springframework.cache.annotation.Cacheable(value = "regexPatterns", key = "#pattern")
+        protected Pattern compilePattern(String pattern) {
+            count.incrementAndGet();
+            return Pattern.compile(pattern);
+        }
+    }
+
+    @Autowired
+    CountingRegexService service;
+
+    @Test
+    void validateWorks() {
+        assertThat(service.validateRegex("a+")).isTrue();
+        assertThat(service.validateRegex("[")).isFalse();
+    }
+
+    @Test
+    void testRegexWorks() {
+        List<Boolean> res = service.testRegex("a+", List.of("a", "b"));
+        assertThat(res).containsExactly(true, false);
+    }
+
+    @Test
+    void getMatchesWorks() {
+        List<String> matches = service.getMatches("a+", "baaab");
+        assertThat(matches).containsExactly("aaa", "a");
+    }
+
+    @Test
+    void cachingWorks() {
+        service.validateRegex("a+");
+        service.validateRegex("a+");
+        assertThat(service.count.get()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add RegexService with cached Pattern compilation
- provide RegexTemplateLibrary
- expose RegexController endpoints to validate and test regexes
- include DTO classes for regex operations
- add tests for service caching and controller endpoints

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6886596c55b4832e99eb0cbf507a973f