### PR TITLE
Add basic RegexBuilder UI

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,6 +15,9 @@ export default function Layout() {
           <Button color="inherit" component={Link} to="/algorithm-builder">
             Algorithm Builder
           </Button>
+          <Button color="inherit" component={Link} to="/regex-builder">
+            Regex Builder
+          </Button>
         </Toolbar>
       </AppBar>
       <main>

--- a/frontend/src/components/RegexBuilder.stories.tsx
+++ b/frontend/src/components/RegexBuilder.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import RegexBuilder from './RegexBuilder'
+
+const meta: Meta<typeof RegexBuilder> = {
+  title: 'Components/RegexBuilder',
+  component: RegexBuilder,
+}
+export default meta
+
+export const Basic: StoryObj<typeof RegexBuilder> = {}

--- a/frontend/src/components/RegexBuilder.tsx
+++ b/frontend/src/components/RegexBuilder.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { Box, TextField, Typography } from '@mui/material'
+
+export type BlockType = 'literal' | 'class' | 'quantifier'
+
+interface Block {
+  id: number
+  type: BlockType
+  value: string
+}
+
+const palette: { label: string; type: BlockType; value: string }[] = [
+  { label: 'Literal', type: 'literal', value: 'text' },
+  { label: 'Digit', type: 'class', value: '\\d' },
+  { label: 'Word', type: 'class', value: '\\w' },
+  { label: 'Whitespace', type: 'class', value: '\\s' },
+  { label: 'Optional ?', type: 'quantifier', value: '?' },
+  { label: 'Zero or more *', type: 'quantifier', value: '*' },
+  { label: 'One or more +', type: 'quantifier', value: '+' },
+]
+
+const colorMap: Record<BlockType, string> = {
+  literal: '#c8e6c9',
+  class: '#bbdefb',
+  quantifier: '#ffe0b2',
+}
+
+export default function RegexBuilder() {
+  const [blocks, setBlocks] = useState<Block[]>([])
+  const [testText, setTestText] = useState('')
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    const data = e.dataTransfer.getData('text/plain')
+    if (!data) return
+    const item = JSON.parse(data) as { type: BlockType; value: string }
+    setBlocks((prev) => [...prev, { id: Date.now() + Math.random(), ...item }])
+  }
+
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault()
+
+  const updateBlock = (id: number, value: string) => {
+    setBlocks((prev) => prev.map((b) => (b.id === id ? { ...b, value } : b)))
+  }
+
+  const regexString = blocks.map((b) => b.value).join('')
+
+  let matches: string[] = []
+  try {
+    if (regexString) {
+      const r = new RegExp(regexString, 'g')
+      matches = [...testText.matchAll(r)].map((m) => m[0])
+    }
+  } catch {
+    // ignore invalid regex
+  }
+
+  return (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <div style={{ width: 200 }}>
+        <Typography variant="h6" gutterBottom>
+          Palette
+        </Typography>
+        {palette.map((item) => (
+          <div
+            key={item.label}
+            draggable
+            onDragStart={(e) =>
+              e.dataTransfer.setData(
+                'text/plain',
+                JSON.stringify({ type: item.type, value: item.value })
+              )
+            }
+            style={{
+              background: colorMap[item.type],
+              padding: 4,
+              marginBottom: 4,
+              cursor: 'grab',
+            }}
+          >
+            {item.label}
+          </div>
+        ))}
+      </div>
+      <div style={{ flex: 1 }}>
+        <Typography variant="h6" gutterBottom>
+          Workspace
+        </Typography>
+        <Box
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          sx={{ minHeight: 60, border: '1px dashed #ccc', p: 1 }}
+        >
+          {blocks.map((b) => (
+            <input
+              key={b.id}
+              value={b.value}
+              onChange={(e) => updateBlock(b.id, e.target.value)}
+              style={{
+                background: colorMap[b.type],
+                marginRight: 4,
+                border: 'none',
+                padding: '2px 4px',
+                borderRadius: 4,
+              }}
+            />
+          ))}
+        </Box>
+        <Typography sx={{ mt: 2 }}>Regex: {regexString}</Typography>
+        <TextField
+          label="Test text"
+          fullWidth
+          sx={{ my: 1 }}
+          value={testText}
+          onChange={(e) => setTestText(e.target.value)}
+        />
+        <Typography>Matches: {matches.join(', ')}</Typography>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css'
 import Layout from './components/Layout'
 import HomePage from './pages/HomePage'
 import AlgorithmBuilder from './pages/AlgorithmBuilder'
+import RegexBuilderPage from './pages/RegexBuilderPage'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -13,6 +14,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/" element={<Layout />}>
           <Route index element={<HomePage />} />
           <Route path="algorithm-builder" element={<AlgorithmBuilder />} />
+          <Route path="regex-builder" element={<RegexBuilderPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/RegexBuilderPage.tsx
+++ b/frontend/src/pages/RegexBuilderPage.tsx
@@ -1,0 +1,9 @@
+import RegexBuilder from '../components/RegexBuilder'
+
+export default function RegexBuilderPage() {
+  return (
+    <div style={{ padding: 16 }}>
+      <RegexBuilder />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `RegexBuilder` component with drag and drop blocks
- show regex preview and testing interface
- wire builder page and route
- expose a Storybook story

## Testing
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688657b5dd04832e95e49a3edd1beb38